### PR TITLE
UTF-8 characters

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -267,10 +267,9 @@ module Readability
           # Otherwise, replace the element with its contents
         else
           if replace_with_whitespace[el.node_name]
-            # Adding &nbsp; here, because swap removes regular spaaces
-            el.swap('&nbsp;' << el.text << '&nbsp;')
+            el.swap(Nokogiri::XML::Text.new(' ' << el.text << ' ', el.document))
           else
-            el.swap(el.text)
+            el.swap(Nokogiri::XML::Text.new(el.text, el.document))
           end
         end
 


### PR DESCRIPTION
ruby-readability sometimes fails to process pages with UTF-8 characters.
It is due to the use of plain string when swaping nokogori nodes. It can be fixed by using nokogiri text node instead.
