### PR TITLE
Don't assume all pages are UTF-8

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -9,7 +9,8 @@ module Readability
       :remove_unlikely_candidates => true,
       :weight_classes => true,
       :clean_conditionally => true,
-      :remove_empty_nodes => true
+      :remove_empty_nodes => true,
+      :encoding => 'UTF-8'
     }.freeze
 
     attr_accessor :options, :html
@@ -20,11 +21,12 @@ module Readability
       @remove_unlikely_candidates = @options[:remove_unlikely_candidates]
       @weight_classes = @options[:weight_classes]
       @clean_conditionally = @options[:clean_conditionally]
+      @encoding = @options[:encoding]
       make_html
     end
 
     def make_html
-      @html = Nokogiri::HTML(@input, nil, 'UTF-8')
+      @html = Nokogiri::HTML(@input, nil, @encoding)
     end
 
     REGEXES = {


### PR DESCRIPTION
Many pages out on the web aren't UTF-8. It would be really super awesome if readability shipped with a method for best guessing the pages encoding but this is actually pretty hard to do well.

A quick and easy first step though would be to allow end users to set their own encoding to be used by Nokogiri and this very simple patch does just that.
