### PR TITLE
add method to retrieve page title

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -43,6 +43,11 @@ module Readability
         :videoRe => /http:\/\/(www\.)?(youtube|vimeo)\.com/i
     }
 
+    def title
+      title = @html.css("title").first
+      title ? title.text : nil
+    end
+
     def content(remove_unlikely_candidates = :default)
       @remove_unlikely_candidates = false if remove_unlikely_candidates == false
 

--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -166,6 +166,14 @@ describe Readability do
     it "should return the main page content" do
       @doc.content.should match("Some content")
     end
+
+    it "should return the page title if present" do
+      @doc.title.should match("title!")
+
+      doc = Readability::Document.new("<html><head></head><body><div><p>Some content</p></div></body>",
+                                       :min_text_length => 0, :retry_length => 1)
+      doc.title.should be_nil
+    end
   end
 
   describe "ignoring sidebars" do


### PR DESCRIPTION
Please note that I'm not familiar with RSpec conventions, so the tests might not be up to par.

Indeed, after `gem install rspec`, I had to `s/require 'spec/require 'rspec/` in `spec/spec_helper.rb`, and running `rspec spec/` returns 2 failures (unrelated to my modifications; same on the current master) - so I'm probably going about it wrong somehow...
