### PR TITLE
Empty string raises an exception

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -46,8 +46,8 @@ module Readability
 
     def make_html
       @html = Nokogiri::HTML(@input, nil, @options[:encoding])
-      # In case Nokogiri returns an empty document which can happen, for example, if @input is an empty string
-      @html = Nokogiri::HTML('<body />', nil, @options[:encoding]) if @html.children.length == 1
+      # In case document has no body, such as from empty string or redirect
+      @html = Nokogiri::HTML('<body />', nil, @options[:encoding]) if @html.css('body').length == 0
 
       # Remove html comment tags
       @html.xpath('//comment()').each { |i| i.remove }

--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 require 'spec_helper'
+require 'readability'
 
 describe Readability do
   before do
@@ -358,6 +359,10 @@ describe Readability do
 
     it "should not error with empty content" do
       Readability::Document.new('').content.should == '<div><div></div></div>'
+    end
+
+    it "should not error with a document with no <body>" do
+      Readability::Document.new('<html><head><meta http-equiv="refresh" content="0;URL=http://example.com"></head></html>').content.should == '<div><div></div></div>'
     end
   end
 end


### PR DESCRIPTION
Nokogiri returns an empty document node for empty strings, but this breaks Readability.  Obviously there's not much use in scoring an empty string, but our crawler came across some documents that had this issue so we needed to fix the exception.  In summary, this works:

```
Readability::Document.new('a').content
```

This raises an exception:

```
Readability::Document.new('').content
```

The patch in this pull request fixes the issue.
