### PR TITLE
Fix for issue remove_unlikely_candidates

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -287,7 +287,7 @@ module Readability
     def remove_unlikely_candidates!
       @html.css("*").each do |elem|
         str = "#{elem[:class]}#{elem[:id]}"
-        if str =~ REGEXES[:unlikelyCandidatesRe] && str !~ REGEXES[:okMaybeItsACandidateRe] && (elem.name.downcase != 'html2') && (elem.name.downcase != 'body')
+        if str =~ REGEXES[:unlikelyCandidatesRe] && str !~ REGEXES[:okMaybeItsACandidateRe] && (elem.name.downcase != 'html') && (elem.name.downcase != 'body')
           debug("Removing unlikely candidate - #{str}")
           elem.remove
         end


### PR DESCRIPTION
This fixes the issue reported with issue #23.

It seems that in some cases the node parent name as parsed by Nokogiri is 'html' rather than 'body'
