### PR TITLE
URL escape image src

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -71,7 +71,7 @@ module Readability
       elements = content.css("img").map(&:attributes)
 
         elements.each do |element|
-          next if element["src"]
+          next unless element["src"]
           url     = URI.escape(element["src"].value) 
           height  = element["height"].nil?  ? 0 : element["height"].value.to_i
           width   = element["width"].nil?   ? 0 : element["width"].value.to_i


### PR DESCRIPTION
Some of the image src on the net could include space or other characters that needs to be escaped before calling ImageMagic::Image.open

I've added URI.escape to the parsed URL to fix this issue. 
