### PR TITLE
Don't crash when images don't have a src attribute

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -71,6 +71,8 @@ module Readability
       elements = content.css("img").map(&:attributes)
 
         elements.each do |element|
+          next unless element["src"]
+
           url     = element["src"].value
           height  = element["height"].nil?  ? 0 : element["height"].value.to_i
           width   = element["width"].nil?   ? 0 : element["width"].value.to_i


### PR DESCRIPTION
This happens on a number of websites, for example:
http://venturebeat.com/2012/04/13/instagram-surpasses-40m-users-adds-10m-in-10-days-according-to-api/
http://blog.cyclops3590.com/?p=33
http://apple.com
http://arielpodwal.com/

Not sure how an image tag can exist without a src attribute but skipping those seems like a sensible thing to do and is definitely better than crashing -- which is what happens now.
