### PR TITLE
Removed instances of Ruby 1.9 hash syntax

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -106,7 +106,7 @@ module Readability
       begin
         w, h = FastImage.size(url)
         raise "Couldn't get size." if w.nil? || h.nil?
-        {width: w, height: h}
+        {:width => w, :height => h}
       rescue => e
         debug("Image error: #{e}")
         nil


### PR DESCRIPTION
Gem was installable under Ruby 1.8.7 but wouldn't run.
