### PR TITLE
Update homepage to `cantino/ruby-readability`

### DIFF
--- a/ruby-readability.gemspec
+++ b/ruby-readability.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version     = '0.5.7'
   s.authors     = ["Andrew Cantino", "starrhorne", "libc", "Kyle Maxwell"]
   s.email       = ["andrew@iterationlabs.com"]
-  s.homepage    = "http://github.com/iterationlabs/ruby-readability"
+  s.homepage    = "http://github.com/cantino/ruby-readability"
   s.summary     = %q{Port of arc90's readability project to ruby}
   s.description = %q{Port of arc90's readability project to ruby}
 


### PR DESCRIPTION
The `gemspec` file should refer to the current homepage of ruby-readability: `cantino/ruby-redability`.
