### PR TITLE
Use hash parameters compatible with Ruby 1.8.7

### DIFF
--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -476,9 +476,9 @@ describe Readability do
     before do
       @code = File.read(File.dirname(__FILE__) + "/fixtures/code.html")
       @content  = Readability::Document.new(@code, 
-                                        tags: %w[div p img a ul ol li h1 h2 h3 h4 h5 h6 blockquote strong em b code pre],
-                                        attributes: %w[src href],
-                                        remove_empty_nodes: false).content
+                                        :tags => %w[div p img a ul ol li h1 h2 h3 h4 h5 h6 blockquote strong em b code pre],
+                                        :attributes => %w[src href],
+                                        :remove_empty_nodes => false).content
       @doc = Nokogiri::HTML(@content)
     end
 


### PR DESCRIPTION
Old-style hash parameters are used everywhere in this project, there is no need to force 1.9-style hash parameters.
