### PR TITLE
Use XHTML serialization instead of HTML

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -419,7 +419,7 @@ module Readability
       end
 
       # Get rid of duplicate whitespace
-      node.to_html.gsub(/[\r\n\f]+/, "\n" )
+      node.to_xhtml.gsub(/[\r\n\f]+/, "\n" )
     end
 
     def clean_conditionally(node, candidates, selector)


### PR DESCRIPTION
Ask Nokogiri to serialize output as XHTML instead of HTML. Such output is compatible with HTML 4, HTML 5 and XML while the HTML-only serialization is not compatible with XML.
