### PR TITLE
Avoid "could not reparent node" error when removing every tag.

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -411,10 +411,16 @@ module Readability
 
           # Otherwise, replace the element with its contents
         else
-          if replace_with_whitespace[el.node_name]
-            el.swap(Nokogiri::XML::Text.new(' ' << el.text << ' ', el.document))
+          # If element is root, replace the node as a text node
+          if el.parent.nil?
+            node = Nokogiri::XML::Text.new(el.text, el.document)
+            break
           else
-            el.swap(Nokogiri::XML::Text.new(el.text, el.document))
+            if replace_with_whitespace[el.node_name]
+              el.swap(Nokogiri::XML::Text.new(' ' << el.text << ' ', el.document))
+            else
+              el.swap(Nokogiri::XML::Text.new(el.text, el.document))
+            end
           end
         end
 

--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -490,4 +490,22 @@ describe Readability do
       @doc.css("pre code").text.should == "\nsecond\n  indented\n    "
     end
   end
+
+  describe "remove all tags" do
+    it "should work for an incomplete piece of HTML" do
+      doc = Readability::Document.new('<div>test</div', :tags => [])
+      doc.content.should == 'test'
+    end
+
+    it "should work for a HTML document" do
+      doc = Readability::Document.new('<html><head><title>title!</title></head><body><div><p>test</p></div></body></html>',
+                                      :tags => [])
+      doc.content.should == 'test'
+    end
+
+    it "should work for a plain text" do
+      doc = Readability::Document.new('test', :tags => [])
+      doc.content.should == 'test'
+    end
+  end
 end


### PR DESCRIPTION
This is a fix for issue [#50](https://github.com/cantino/ruby-readability/issues/50).

When trying to remove all tags from the doc, the "could not reparent node" is thrown from Nokogiri. That's because we are reparenting a root node. Some logic is added to check if it is root to avoid the error.
