### PR TITLE
Fix undefined local variable 'name'

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -455,7 +455,7 @@ module Readability
           content_length = el.text.strip.length  # Count the text length excluding any surrounding whitespace
           link_density = get_link_density(el)
 
-          reason = clean_conditionally_reason?(counts, content_length, options, weight, link_density)
+          reason = clean_conditionally_reason?(name, counts, content_length, options, weight, link_density)
           if reason
             debug("Conditionally cleaned #{name}##{el[:id]}.#{el[:class]} with weight #{weight} and content score #{content_score} because it has #{reason}.")
             el.remove
@@ -464,7 +464,7 @@ module Readability
       end
     end
 
-    def clean_conditionally_reason?(counts, content_length, options, weight, link_density)
+    def clean_conditionally_reason?(name, counts, content_length, options, weight, link_density)
       if counts["img"] > counts["p"]
         "too many images"
       elsif counts["li"] > counts["p"] && name != "ul" && name != "ol"

--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -541,4 +541,13 @@ describe Readability do
 
     end
   end
+
+  describe "clean_conditionally_reason?" do
+    let (:list_fixture) { "<div><p>test</p>#{'<li></li>' * 102}" }
+
+    it "does not raise error" do
+      @doc = Readability::Document.new(list_fixture)
+      expect { @doc.content }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
Local variable 'name' defined in 'Document#clean_conditionally' does not exists in 'Document#clean_conditionally_reason?'.
