### PR TITLE
Fix failing CI

### DIFF
--- a/ruby-readability.gemspec
+++ b/ruby-readability.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec", ">= 2.8"
   s.add_development_dependency "rspec-expectations", ">= 2.8"
-  s.add_development_dependency "rr", ">= 1.0"
   s.add_dependency 'nokogiri', '>= 1.6.0'
   s.add_dependency 'guess_html_encoding', '>= 0.0.4'
 end

--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -19,7 +19,7 @@ describe Readability do
         </body>
       </html>
     HTML
-    
+
     @simple_html_with_img_no_text = <<-HTML
     <html>
       <head>
@@ -32,7 +32,7 @@ describe Readability do
       </body>
       </html>
     HTML
-    
+
     @simple_html_with_img_in_noscript = <<-HTML
     <html>
       <head>
@@ -40,8 +40,8 @@ describe Readability do
       </head>
       <body class='main'>
         <div class="article-img">
-        <img src="http://img.thesun.co.uk/multimedia/archive/00703/sign_up_emails_682__703711a.gif" width="660" 
-        height="317" alt="test" class="lazy" 
+        <img src="http://img.thesun.co.uk/multimedia/archive/00703/sign_up_emails_682__703711a.gif" width="660"
+        height="317" alt="test" class="lazy"
         data-original="http://img.thesun.co.uk/multimedia/archive/01416/dim_1416768a.jpg">
         <noscript><img src="http://img.thesun.co.uk/multimedia/archive/01416/dim_1416768a.jpg"></noscript>
         </div>
@@ -61,17 +61,17 @@ describe Readability do
 
       FakeWeb.register_uri(:get, "http://img.thesun.co.uk/multimedia/archive/01416/dim_1416768a.jpg",
                            :body => File.read(File.dirname(__FILE__) + "/fixtures/images/dim_1416768a.jpg"))
-                           
+
       FakeWeb.register_uri(:get, "http://img.thesun.co.uk/multimedia/archive/00703/sign_up_emails_682__703711a.gif",
                            :body => File.read(File.dirname(__FILE__) + "/fixtures/images/sign_up_emails_682__703711a.gif"))
-                        
-      FakeWeb.register_uri(:get, "http://img.thesun.co.uk/multimedia/archive/00703/sign_up_emails_682__703712a.gif",                                            
+
+      FakeWeb.register_uri(:get, "http://img.thesun.co.uk/multimedia/archive/00703/sign_up_emails_682__703712a.gif",
                            :body => File.read(File.dirname(__FILE__) + "/fixtures/images/sign_up_emails_682__703712a.gif"))
 
       # Register images for codinghorror
-      FakeWeb.register_uri(:get, 'http://blog.codinghorror.com/content/images/2014/Sep/JohnPinhole.jpg',                                            
+      FakeWeb.register_uri(:get, 'http://blog.codinghorror.com/content/images/2014/Sep/JohnPinhole.jpg',
                            :body => File.read(File.dirname(__FILE__) + "/fixtures/images/JohnPinhole.jpg"))
-      FakeWeb.register_uri(:get, 'http://blog.codinghorror.com/content/images/2014/Sep/Confusion_of_Tongues.png',                                            
+      FakeWeb.register_uri(:get, 'http://blog.codinghorror.com/content/images/2014/Sep/Confusion_of_Tongues.png',
                            :body => File.read(File.dirname(__FILE__) + "/fixtures/images/Confusion_of_Tongues.png"))
     end
 
@@ -117,7 +117,7 @@ describe Readability do
           </body>
         </html>
       HTML
-      do_not_allow(@doc).load_image(anything)
+      expect(@doc).not_to receive(:get_image_size)
       @doc.images.should == []
     end
 
@@ -169,17 +169,17 @@ describe Readability do
           @doc.images.should == ["http://news.bbcimg.co.uk/media/images/57060000/gif/_57060487_sub_escapes304x416.gif"]
           @doc.best_candidate_has_image.should == true
         end
-        
+
         it "should not miss an image if it exists by itself in a div without text" do
           @doc = Readability::Document.new(@simple_html_with_img_no_text,:tags => %w[div p img a], :attributes => %w[src href], :remove_empty_nodes => false, :do_not_guess_encoding => true)
           @doc.images.should == ["http://img.thesun.co.uk/multimedia/archive/01416/dim_1416768a.jpg"]
         end
-        
+
         it "should not double count an image between script and noscript" do
           @doc = Readability::Document.new(@simple_html_with_img_in_noscript,:tags => %w[div p img a], :attributes => %w[src href], :remove_empty_nodes => false, :do_not_guess_encoding => true)
           @doc.images.should == ["http://img.thesun.co.uk/multimedia/archive/00703/sign_up_emails_682__703711a.gif", "http://img.thesun.co.uk/multimedia/archive/01416/dim_1416768a.jpg"]
         end
-        
+
       end
     end
   end
@@ -211,7 +211,7 @@ describe Readability do
       HTML
       doc.author.should eql("Austin Fonacier")
     end
-    
+
     it "should pick up readability's recommended author format" do
       doc = Readability::Document.new(<<-HTML)
         <html>
@@ -226,7 +226,7 @@ describe Readability do
       HTML
       doc.author.should eql("Austin Fonacier")
     end
-    
+
     it "should pick up vcard fn" do
       doc = Readability::Document.new(<<-HTML)
         <html>
@@ -242,7 +242,7 @@ describe Readability do
       HTML
       doc.author.should eql("Austin Fonacier")
     end
-    
+
     it "should pick up <a rel='author'>" do
       doc = Readability::Document.new(<<-HTML)
         <html>
@@ -254,7 +254,7 @@ describe Readability do
       HTML
       doc.author.should eql("Danny Banks (rel)")
     end
-    
+
     it "should pick up <div id='author'>" do
       doc = Readability::Document.new(<<-HTML)
         <html>
@@ -475,13 +475,13 @@ describe Readability do
         end
 
         it "should allow encoding guessing to be skipped" do
-          do_not_allow(GuessHtmlEncoding).encode
+          expect(GuessHtmlEncoding).to_not receive(:encode)
           doc = Readability::Document.new(@simple_html_fixture, :do_not_guess_encoding => true)
           doc.content
         end
 
         it "should allow encoding guessing to be overridden" do
-          do_not_allow(GuessHtmlEncoding).encode
+          expect(GuessHtmlEncoding).to_not receive(:encode)
           doc = Readability::Document.new(@simple_html_fixture, :encoding => "UTF-8")
           doc.content
         end
@@ -505,42 +505,42 @@ describe Readability do
       Readability::Document.new('<html><head><meta http-equiv="refresh" content="0;URL=http://example.com"></head></html>').content.should == '<div><div></div></div>'
     end
   end
-  
+
   describe "No side-effects" do
     before do
       @bbc      = File.read(File.dirname(__FILE__) + "/fixtures/bbc.html")
       @nytimes  = File.read(File.dirname(__FILE__) + "/fixtures/nytimes.html")
       @thesum   = File.read(File.dirname(__FILE__) + "/fixtures/thesun.html")
     end
-    
+
     it "should not have any side-effects when calling content() and then images()" do
-      @doc=Readability::Document.new(@nytimes, :tags => %w[div p img a], :attributes => %w[src href], :remove_empty_nodes => false, 
+      @doc=Readability::Document.new(@nytimes, :tags => %w[div p img a], :attributes => %w[src href], :remove_empty_nodes => false,
       :do_not_guess_encoding => true)
       @doc.images.should == ["http://graphics8.nytimes.com/images/2011/12/02/opinion/02fixes-freelancersunion/02fixes-freelancersunion-blog427.jpg"]
       @doc.content
       @doc.images.should == ["http://graphics8.nytimes.com/images/2011/12/02/opinion/02fixes-freelancersunion/02fixes-freelancersunion-blog427.jpg"]
     end
-    
+
     it "should not have any side-effects when calling content() multiple times" do
-       @doc=Readability::Document.new(@nytimes, :tags => %w[div p img a], :attributes => %w[src href], :remove_empty_nodes => false, 
+       @doc=Readability::Document.new(@nytimes, :tags => %w[div p img a], :attributes => %w[src href], :remove_empty_nodes => false,
         :do_not_guess_encoding => true)
        @doc.content.should ==  @doc.content
     end
-    
+
     it "should not have any side-effects when calling content and images multiple times" do
-       @doc=Readability::Document.new(@nytimes, :tags => %w[div p img a], :attributes => %w[src href], :remove_empty_nodes => false, 
+       @doc=Readability::Document.new(@nytimes, :tags => %w[div p img a], :attributes => %w[src href], :remove_empty_nodes => false,
         :do_not_guess_encoding => true)
        @doc.images.should == ["http://graphics8.nytimes.com/images/2011/12/02/opinion/02fixes-freelancersunion/02fixes-freelancersunion-blog427.jpg"]
        @doc.content.should ==  @doc.content
        @doc.images.should == ["http://graphics8.nytimes.com/images/2011/12/02/opinion/02fixes-freelancersunion/02fixes-freelancersunion-blog427.jpg"]
     end
-  
+
   end
-  
+
   describe "Code blocks" do
     before do
       @code = File.read(File.dirname(__FILE__) + "/fixtures/code.html")
-      @content  = Readability::Document.new(@code, 
+      @content  = Readability::Document.new(@code,
                                         :tags => %w[div p img a ul ol li h1 h2 h3 h4 h5 h6 blockquote strong em b code pre],
                                         :attributes => %w[src href],
                                         :remove_empty_nodes => false).content

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,10 @@
 require 'rubygems'
 require 'readability'
-require 'rr'
 require 'fakeweb'
 
 FakeWeb.allow_net_connect = false
 
 RSpec.configure do |config|
-  config.mock_with :rr
-
   config.expect_with :rspec do |c|
     c.syntax = [:should, :expect]
   end


### PR DESCRIPTION
* Drop RR and use RSpec for expectations instead.
* Fix invalid test since `load_image` was renamed to `get_image_size` in 6fa12bb.
* Strip excess whitespace ([view PR with whitespace changes ignored](https://github.com/cantino/ruby-readability/pull/85/files?w=1))

Closes #84
