### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,25 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['1.9', '2.7']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - 2.1.1
-  - 2.0.0
-  - 1.9.3
-script: "bundle exec rspec"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ webpage. It is a Ruby port of arc90's readability project.
 Build Status
 ------------
 
-[![Build Status](https://travis-ci.org/cantino/ruby-readability.png)](https://travis-ci.org/cantino/ruby-readability)
+[![Build Status](https://github.com/antino/ruby-readability/actions/workflows/ruby/badge.svg)](https://github.com/antino/ruby-readability/actions)
 
 Install
 -------


### PR DESCRIPTION
https://www.travis-ci.org/ "will be shutting down in several weeks".

Although this could be  moved to travis-ci.com, GitHub Actions is a better option IMO.

TODO:
- [x] wait for #85 so the tests are passing
- [x] update the badge in the README
- [ ] An admin may need to enable GitHub Actions in this repo.