### PR TITLE
Allow CI to run on PRs from forks

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,10 +1,6 @@
 name: Ruby
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Currently it doesn't run, e.g. see https://github.com/cantino/ruby-readability/pull/91