### PR TITLE
Ignore redundant nesting when checking for related siblings

### DIFF
--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -518,7 +518,7 @@ describe Readability do
     end
 
     it "climbs the DOM tree to the closest ancestor that has siblings when checking for related siblings" do
-      @doc = Readability::Document.new(<<-HTML, min_text_length: 1, elements_to_score: ["h1", "p"], likely_siblings: ["section"])
+      @doc = Readability::Document.new(<<-HTML, min_text_length: 1, elements_to_score: ["h1", "p"], likely_siblings: ["section"], ignore_redundant_nesting: true)
         <html>
           <head>
             <title>title!</title>


### PR DESCRIPTION
If the best candidate is in an element all by itself, then we should probably check its nearest ancestor that has siblings when considering whether to append siblings that meet the score threshold.

For example, in the example below, we would now include the second paragraph whereas previous we would not.


```html
<div>
  <div>
    <p>This is the best candidate.</p>
  </div>
</div>
<p>This paragraph meets the score threshold.</p>
```

Note that this changes behaviour. We could put this change behind an option if preferred. I think this will improve the extraction for most use cases, though, and none of the existing test cases fail.