### PR TITLE
Add gem metadata

### DIFF
--- a/ruby-readability.gemspec
+++ b/ruby-readability.gemspec
@@ -9,6 +9,10 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/cantino/ruby-readability"
   s.summary     = %q{Port of arc90's readability project to ruby}
   s.description = %q{Port of arc90's readability project to ruby}
+  s.metadata    = {
+    "bug_tracker_uri" => "https://github.com/cantino/ruby-readability/issues",
+    "source_code_uri" => "https://github.com/cantino/ruby-readability",
+  }
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
For whatever reason [rubygems](https://rubygems.org/gems/ruby-readability) has incorrect links to this gem's "Source Code" and "Bug Tracker". This also seems to affect commit messages generated by Dependabot (see, e.g. https://github.com/discourse/discourse/pull/28653 - incorrect links and an empty change list)

Hopefully this change will cause rubygems to update those links.