### PR TITLE
Update bin/readability to work with Ruby 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Example
     require 'readability'
     require 'open-uri'
 
-    source = open('http://lab.arc90.com/experiments/readability/').read
+    source = URI.parse('http://lab.arc90.com/experiments/readability/').read
     puts Readability::Document.new(source).content
 
 

--- a/bin/readability
+++ b/bin/readability
@@ -2,7 +2,7 @@
 require 'rubygems'
 require 'open-uri'
 require 'optparse'
-require File.dirname(__FILE__) + '/../lib/readability'
+require_relative '../lib/readability'
 
 options = { :debug => false, :images => false }
 options_parser = OptionParser.new do |opts|
@@ -28,7 +28,7 @@ if ARGV.length != 1
   exit 1
 end
 
-text = open(ARGV.first).read
+text = URI.parse(ARGV.first).read
 params = if options[:images]
   { :tags => %w[div p img a],
     :attributes => %w[src href],


### PR DESCRIPTION
These changes should be backwards compatible with older Ruby versions according to the docs and testing it on Ruby 2.7 and 3.2.

Changes:
1. Use `require_relative` to avoid loading errors.
2. Use `URI.parse(...).read` instead of `open(...).read`
    - This seems to be backwards compatible with older Ruby versions. - Ex. https://www.rubydoc.info/stdlib/open-uri/2.3.1/OpenURI
    - The behavior should be identical to what we saw before.
    - `open(...).read` got deprecated in Ruby 3.0

---

Do you think it's worth adding an integration test for this on CI?

Something like this would probably work to sanity check this. Probably would need to add more Rubies to CI though to make it a better check. Maybe not worth the effort.

```
bin/readability https://github.com/cantino/ruby-readability
```